### PR TITLE
freertos_variscite: Prevent git clone failing the build when the repo directory exists

### DIFF
--- a/src/apps/utils/freertos_variscite.mk
+++ b/src/apps/utils/freertos_variscite.mk
@@ -14,7 +14,9 @@ CM_BUILD_TARGETS ?= debug ddr_debug
 freertos_variscite:
 	@[ $(SOCFAMILY) != IMX -o $(DISTROVARIANT) = base -o $(DISTROVARIANT) = tiny -o $(FREERTOS_SUPPORT) = false ] && exit || \
 	$(call fbprint_b,"freertos_variscite") && \
-	git clone $(repo_freertos_variscite_url) --no-checkout $(PKGDIR)/apps/utils/freertos_variscite && \
+	if [ ! -d $(PKGDIR)/apps/utils/freertos_variscite ]; then \
+		git clone $(repo_freertos_variscite_url) --no-checkout $(PKGDIR)/apps/utils/freertos_variscite; \
+	fi && \
 	cd $(PKGDIR)/apps/utils/freertos_variscite && \
 	git checkout $(FREERTOS_COMMIT) && \
 	$(call repo-mngr,fetch,meta_variscite_bsp_imx) && \


### PR DESCRIPTION
When doing multiple subsequent builds (without `var_build_image --cleanall`) for a board that uses FreeRTOS, the build fails because here
https://github.com/varigit/flexbuild/blob/a1294369307da83b00fb95dc906ddb6146350a46/src/apps/utils/freertos_variscite.mk#L17
`git clone` fails since the folder already exists, some path variables are not set and the make command fails.

This is solving it in a way that the repository is cloned only if `.git` subfolder does not exist preventing the failing `git clone`.

Our board is `imx93-var-som`.